### PR TITLE
Allow for RDF* syntax

### DIFF
--- a/src/main/resources/org/renci/blazegraph/blazegraph.properties
+++ b/src/main/resources/org/renci/blazegraph/blazegraph.properties
@@ -29,7 +29,7 @@ com.bigdata.journal.AbstractJournal.maximumExtent=209715200
 ##                                                                                                                                                 
 com.bigdata.rdf.sail.truthMaintenance=false
 com.bigdata.rdf.store.AbstractTripleStore.quads=true
-com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers=false
+com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers=true
 com.bigdata.rdf.store.AbstractTripleStore.textIndex=true
 com.bigdata.rdf.store.AbstractTripleStore.axiomsClass=com.bigdata.rdf.axioms.NoAxioms
 


### PR DESCRIPTION
Close if you feel this has performance implications. It's not really required as the default as most bgr use cases don't use rdf reification anyway. But if there is zero downsides it would be nice to have